### PR TITLE
Add `camelcase` to node_modules list

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -42,6 +42,7 @@ const nodeModulesThatNeedToBeParsedBecauseTheyExposeES6 = [
   "acorn-jsx",
   "better-opn",
   "boxen",
+  "camelcase",
   "chalk",
   "color-convert",
   "commander",


### PR DESCRIPTION
This package (`camelcase`) is causing a similar ES6 syntax error in IE11 (with storybook 6.3.6, addon-essentials, addon-links & addon-postcss). 

Adding `camelcase` to `nodeModulesThatNeedToBeParsedBecauseTheyExposeES6` resolves the issue for me.

<img width="321" alt="Screenshot 2021-07-28 at 21 33 53" src="https://user-images.githubusercontent.com/98794/127392001-13de1f86-2b69-4d9b-8a53-0e76e556e00c.png">
<img width="404" alt="Screenshot 2021-07-28 at 21 33 43" src="https://user-images.githubusercontent.com/98794/127392022-27e54823-315c-49d0-8e60-42363ca5dbd9.png">
