### PR TITLE
fix: set loose to `true` in `@babel/preset-env`

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -10,6 +10,7 @@ interface BabelOptions {
 const ie11Preset = [
   "@babel/preset-env",
   {
+    loose: true,
     targets: {
       ie: "11",
     },


### PR DESCRIPTION
This fixes #7

Not sure if it has any implications related to actual IE11 compatibility.