### PR TITLE
feature: `includeModules` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,22 @@ module.exports = {
   addons: ["@storybook/addon-ie11"],
 };
 ```
+
+## Options
+
+### `includeModules`
+
+An array of npm module names to be transpiled by Babel (in addition to the default npm modules configured via `@storybook/addon-intl`).
+
+```js
+module.exports = {
+  addons: [
+    {
+      name: "@storybook/addon-ie11",
+      options: {
+        includeModules: ["@react-theming/storybook-addon", "react-hook-form"],
+      },
+    },
+  ],
+};
+```

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -38,9 +38,9 @@ export const managerBabel = (config: BabelOptions): BabelOptions => {
 };
 
 const nodeModulesThatNeedToBeParsedBecauseTheyExposeES6 = [
-  "@storybook[\\\\/]node_logger",
-  "@testing-library[\\\\/]dom",
-  "@testing-library[\\\\/]user-event",
+  "@storybook/node_logger",
+  "@testing-library/dom",
+  "@testing-library/user-event",
   "acorn-jsx",
   "ansi-align",
   "ansi-colors",

--- a/src/preset.ts
+++ b/src/preset.ts
@@ -7,6 +7,10 @@ interface BabelOptions {
   presets: PluginItem[] | null;
 }
 
+interface PresetOptions {
+  includeModules?: string[];
+}
+
 const ie11Preset = [
   "@babel/preset-env",
   {
@@ -66,38 +70,62 @@ const nodeModulesThatNeedToBeParsedBecauseTheyExposeES6 = [
   "uuid",
 ];
 
-const include = new RegExp(
-  `[\\\\/]node_modules[\\\\/](${nodeModulesThatNeedToBeParsedBecauseTheyExposeES6.join(
-    "|"
-  )})`
-);
+const escapeDirectorySeparators = (module: string) => {
+  return module.replace(/\//, "[\\\\/]");
+};
 
-const es6Loader = {
-  test: /\.js$/,
-  use: [
-    {
-      loader: require.resolve("babel-loader"),
-      options: {
-        sourceType: "unambiguous",
-        presets: [ie11Preset],
+const createEs6Loader = (options?: PresetOptions) => {
+  const modules = [
+    ...nodeModulesThatNeedToBeParsedBecauseTheyExposeES6,
+    ...(options?.includeModules ?? []),
+  ];
+
+  const include = new RegExp(
+    `[\\\\/]node_modules[\\\\/](${modules
+      .map(escapeDirectorySeparators)
+      .join("|")})`
+  );
+
+  const es6Loader = {
+    test: /\.js$/,
+    use: [
+      {
+        loader: require.resolve("babel-loader"),
+        options: {
+          sourceType: "unambiguous",
+          presets: [ie11Preset],
+        },
       },
-    },
-  ],
-  include,
+    ],
+    include,
+  };
+
+  return es6Loader;
 };
 
 export const managerWebpack = (
-  webpackConfig: Configuration = {}
-): Configuration => ({
-  ...webpackConfig,
-  module: {
-    ...webpackConfig.module,
-    rules: [...(webpackConfig.module?.rules ?? []), es6Loader],
-  },
-});
+  webpackConfig: Configuration = {},
+  options?: PresetOptions
+): Configuration => {
+  const es6Loader = createEs6Loader(options);
 
-export const webpack = (webpackConfig: Configuration = {}): Configuration => {
+  return {
+    ...webpackConfig,
+    module: {
+      ...webpackConfig.module,
+      rules: [...(webpackConfig.module?.rules ?? []), es6Loader],
+    },
+  };
+};
+
+export const webpack = (
+  webpackConfig: Configuration = {},
+  options: PresetOptions
+): Configuration => {
   logger.info(`=> Using IE11 addon`);
+
+  const es6Loader = createEs6Loader(options);
+
   return {
     ...webpackConfig,
     module: {


### PR DESCRIPTION
This change provides an option to include extra modules names for transpilation, in addition to the default modules baked into `@storybook/addon-ie11`.

This is as per [@casperdue's suggestion](https://github.com/storybookjs/addon-ie11/issues/1#issuecomment-931273702) in the following ticket: ["Add `@storybook/*` to the ESM modules"](https://github.com/storybookjs/addon-ie11/issues/1).

**Usage:**
```js
//.storybook/main.js

module.exports = {
  addons: [
    {
      name: '@storybook/addon-ie11',
      options: {
        includeModules: ['react-hook-form'] // list any extra npm packages that need to be transpiled by Babel
      }
    }
  ]
}
```